### PR TITLE
Fix a bug, add explorer.exe to the allowlist and add integrity level checks

### DIFF
--- a/raccine.cpp
+++ b/raccine.cpp
@@ -77,7 +77,7 @@ BOOL IntegrityIsSystem(HANDLE hProcess) {
         else if (dwIntegrityLevel >= SECURITY_MANDATORY_SYSTEM_RID)
         {
             // System Integrity
-            return FALSE;
+            return TRUE;
         }
     }
 }

--- a/raccine.cpp
+++ b/raccine.cpp
@@ -56,7 +56,7 @@ BOOL isallowlisted(DWORD pid) {
         do {
             if (pe32.th32ProcessID == pid){
                 for (uint8_t i = 0; i < arraysize(allowlist); i++) {
-                    if (!_tcscmp((TCHAR*)pe32.szExeFile, allowlist[i])) {
+                    if (_tcscmp((TCHAR*)pe32.szExeFile, allowlist[i]) == 0 ) {
 
                         HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pe32.th32ProcessID);
                         if (hProcess != NULL)

--- a/raccine.cpp
+++ b/raccine.cpp
@@ -49,14 +49,19 @@ BOOL isallowlisted(DWORD pid) {
     HANDLE hSnapshot;
     hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     __try {
+        
         if(hSnapshot == INVALID_HANDLE_VALUE) __leave;
+        
         ZeroMemory(&pe32, sizeof(pe32));
         pe32.dwSize = sizeof(pe32);
+
         if (!Process32First(hSnapshot, &pe32)) __leave;
+        
         do {
             if (pe32.th32ProcessID == pid){
                 for (uint8_t i = 0; i < arraysize(allowlist); i++) {
-                    if (_tcscmp((TCHAR*)pe32.szExeFile, allowlist[i]) == 0 ) {
+         
+                    if (_tcsicmp((TCHAR*)pe32.szExeFile, allowlist[i]) == 0 ) {
 
                         HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pe32.th32ProcessID);
                         if (hProcess != NULL)
@@ -74,7 +79,7 @@ BOOL isallowlisted(DWORD pid) {
                                 CloseHandle(hProcess);
                             }
                         }
-                    } 
+                    } // _tcsicmp
                 }
                 break;
             }

--- a/raccine.cpp
+++ b/raccine.cpp
@@ -111,8 +111,9 @@ BOOL isallowlisted(DWORD pid) {
                                 // Are they in the Windows directory?
                                 if (_tcsnicmp(filePath, TEXT("C:\\Windows\\System32\\"), _tcslen(TEXT("C:\\Windows\\System32\\"))) == 0) {
                                     
-                                    if (IntegrityIsSystem(hProcess)) {
+                                    if (IntegrityIsSystem(hProcess) == TRUE) {
                                         CloseHandle(hProcess);
+                                        
                                         return TRUE;
                                     }
                                     


### PR DESCRIPTION
So this pull request does multiple things:

- Fixes a bug in the allowlist check
- Adds explorer to the allowlist (was annoying me when it killed it on my box)
- Added integrity level checking per the issue raised in issue #6 

Tested locally but should be subject to further testing.