### PR TITLE
Add support for bcdedit exploit

### DIFF
--- a/install-raccine.bat
+++ b/install-raccine.bat
@@ -85,6 +85,7 @@ IF '%errorlevel%' NEQ '0' (
 )
 REGEDIT.EXE /S raccine-reg-patch-wmic.reg 
 REGEDIT.EXE /S raccine-reg-patch-wbadmin.reg
+REGEDIT.EXE /S raccine-reg-patch-bcdedit.reg
 ECHO Copying Raccine%ARCH%.exe to C:\Windows\Raccine.exe ...
 COPY Raccine%ARCH%.exe C:\Windows\Raccine.exe
 IF '%errorlevel%' NEQ '0' (
@@ -105,6 +106,7 @@ IF '%errorlevel%' NEQ '0' (
     ECHO Something went wrong. Sorry.
     GOTO MENU
 )
+REGEDIT.EXE /S raccine-reg-patch-bcdedit.reg
 ECHO Copying Raccine%ARCH%.exe to C:\Windows\Raccine.exe ...
 COPY Raccine%ARCH%.exe C:\Windows\Raccine.exe
 IF '%errorlevel%' NEQ '0' (

--- a/raccine-reg-patch-bcdedit.reg
+++ b/raccine-reg-patch-bcdedit.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\bcdedit.exe]
+"Debugger"="Raccine.exe"

--- a/raccine-reg-patch-uninstall.reg
+++ b/raccine-reg-patch-uninstall.reg
@@ -8,3 +8,6 @@ Windows Registry Editor Version 5.00
 
 [-HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wbadmin.exe]
 "Debugger"="Raccine.exe"
+
+[-HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\bcdedit.exe]
+"Debugger"="Raccine.exe"

--- a/raccine.cpp
+++ b/raccine.cpp
@@ -185,6 +185,7 @@ int wmain(int argc, WCHAR* argv[]) {
     bool bVssadmin = false;
     bool bWmic = false;
     bool bWbadmin = false;
+	bool bcdEdit = false;
 
     bool bDelete = false;
     bool bShadow = false;
@@ -194,6 +195,8 @@ int wmain(int argc, WCHAR* argv[]) {
     bool bCatalog = false;
     bool bQuiet = false;
 
+    bool bRecoveryEnabled = false;
+    bool bIgnoreallFailures = false;
 
     if (argc > 1)
     {
@@ -209,6 +212,10 @@ int wmain(int argc, WCHAR* argv[]) {
         else if ((_wcsicmp(L"wbadmin.exe", argv[1]) == 0) ||
             (_wcsicmp(L"wbadmin", argv[1]) == 0)) {
             bWbadmin = true;
+        }
+		else if ((_wcsicmp(L"bcdedit.exe", argv[1]) == 0) ||
+            (_wcsicmp(L"bcdedit", argv[1]) == 0)) {
+            bcdEdit = true;
         }
     }
 
@@ -236,6 +243,12 @@ int wmain(int argc, WCHAR* argv[]) {
         else if (_wcsicmp(L"-quiet", argv[iCount]) == 0) {
             bQuiet = true;
         }
+        else if (_wcsicmp(L"recoveryenabled", argv[iCount]) == 0) {
+            bRecoveryEnabled = true;
+        }
+        else if (_wcsicmp(L"ignoreallfailures", argv[iCount]) == 0) {
+            bIgnoreallFailures = true;
+        }
     }
 
     // OK this is not want we want 
@@ -244,7 +257,9 @@ int wmain(int argc, WCHAR* argv[]) {
         (bVssadmin && bDelete && bShadowStorage) ||      // vssadmin.exe
         (bVssadmin && bResize && bShadowStorage) ||      // vssadmin.exe
         (bWmic && bDelete && bShadowCopy) ||             // wmic.exe
-        (bWbadmin && bDelete && bCatalog && bQuiet)) {   // wbadmin.exe 
+        (bWbadmin && bDelete && bCatalog && bQuiet) || 	 // wbadmin.exe 
+        (bcdEdit && bIgnoreallFailures) ||               // bcdedit.exe
+        (bcdEdit && bRecoveryEnabled)){                  // bcdedit.exe  
 
         wprintf(L"Raccine detected malicious activity\n");
 


### PR DESCRIPTION
I thought it would be a good idea to add this little fix for bcdedit, since ransomware makes a mess out of your registry, too.

bcdedit.exe is often used to disable repair by the Windows Recovery Console on boot/restart after infection. Used by numerous ransomware families and APT malware such as Olympic Destroyer etc ...

Evil commands:
bcdedit.exe /set {default} bootstatuspolicy ignoreallfailures
bcdedit.exe /set {default} recoveryenabled no

What has been added:
- Added new registry file "raccine-reg-patch-bcdedit.reg" to monitor bcdedit.exe
- Added entry in "install-raccine.bat" to watch for bcdedit in SOFT and HARD mode by default
- Added checks for bcdedit in .cpp file
- Added registry uninstaller for bcdedit listener

Great work btw ;) 
