### PR TITLE
Create Raccine.ADML

### DIFF
--- a/GPO/Raccine.ADML
+++ b/GPO/Raccine.ADML
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+    <displayName>Raccine Policy</displayName>
+    <description>Raccine Policy</description>
+    <resources>
+        <stringTable>
+            <string id="L_Raccine_GroupPolicyCategory">Raccine</string>
+            <string id="L_RaccineLogOnly">Enable Raccine Audit Only mode</string>
+            <string id="L_RaccineLogOnlyExplain">
+                When this setting is enabled, Raccine will not terminate any processes.
+
+        If you do not configure this policy setting, Raccine will operate in enforcement mode.
+        
+        If you enable this property setting, Raccine will only log and not take actions.
+            </string>
+            <string id="L_RaccineLogging">Enable eventlog logging</string>
+            <string id="L_RaccineLoggingExplain">
+                When this setting is enabled, Raccine will log key events to the Windows Event Log.
+
+        If you do not configure this policy setting, Raccine will only log to the console and a local file.
+        
+        If you enable this property setting, Raccine will log to the Windows Application Log.
+            </string>
+        </stringTable>
+    </resources>
+</policyDefinitionResources>


### PR DESCRIPTION
Raccine ADMX for GPEDIT.MSC.  In deployment this file goes in C:\Windows\PolicyDefinitions.   The accompanying Raccine.ADML files goes in C:\Windows\PolicyDefinitions\en-US.   To use:
GPEDIT.MSC
+--Computer Configuration
     +---Administrative Templates
            +--- System
                  +---- Raccine
After configuring the changes, you may need to bump gpo by running gpupdate.exe