### PR TITLE
Patch PowerShell downgrade attacks (bypassing the newer security features)

### DIFF
--- a/raccine.cpp
+++ b/raccine.cpp
@@ -392,6 +392,7 @@ int wmain(int argc, WCHAR* argv[]) {
     bool bIgnoreallFailures = false;
     bool bwin32ShadowCopy = false;
     bool bEncodedCommand = false;
+    bool bVersion = false;
 
     // Encoded Command List (Base64)
     WCHAR encodedCommands[11][9] = { L"JAB", L"SQBFAF", L"SQBuAH", L"SUVYI", L"cwBhA", L"aWV4I", L"aQBlAHgA", 
@@ -481,6 +482,9 @@ int wmain(int argc, WCHAR* argv[]) {
         else if (convertedArg.find(L"win32_shadowcopy") != std::string::npos) {
             bwin32ShadowCopy = true;
         }
+        else if (_wcsicmp(L"-version", argv[iCount]) == 0 || _wcsicmp(L"/version", argv[iCount]) == 0) {
+            bVersion = true;
+        }
         // Special comparison of current argument with previous argument
         // allows to check for e.g. -encodedCommand JABbaTheHuttandotherBase64characters
         else if (convertedArgPrev.find(L"-e") != std::string::npos || convertedArgPrev.find(L"/e") != std::string::npos) {
@@ -502,6 +506,7 @@ int wmain(int argc, WCHAR* argv[]) {
         (bWbadmin && bDelete && bCatalog && bQuiet) || 	 // wbadmin.exe 
         (bcdEdit && bIgnoreallFailures) ||               // bcdedit.exe
         (bcdEdit && bRecoveryEnabled) ||                 // bcdedit.exe
+        (bPowerShell && bVersion) ||                     // powershell.exe
         (bPowerShell && bwin32ShadowCopy) ||             // powershell.exe
         (bPowerShell && bEncodedCommand) ||              // powershell.exe
         (bDiskShadow && bDelete && bShadows)) {          // diskshadow.exe


### PR DESCRIPTION
When forcing PowerShell to run using its PowerShell 2.0 engine (read: downgrade), none of the advanced security features (such as transcription) are available, since the older .NET Framework v2.0 is loaded.

All machines running Windows 7 and above will have at least PowerShell 2.0.

How to check if the old engine is enabled:

`Get-WindowsOptionalFeature -Online | Where-Object {$_.FeatureName -match "PowerShellv2"}`

Output:
![Capture](https://user-images.githubusercontent.com/39777434/96591477-94e96080-12e7-11eb-8ec0-687a0cc896fd.PNG)

Up until now, these were the only ways of disabling PowerShell V2 engine:

    - Remove the PowerShell 2.0 Engine from the OS (including image) completely or
    - Apply application blacklisting (using AppLocker) to deny access to PowerShell 2.0 Engine specific .NET assemblies.

To remove the PowerShell 2.0 Engine from the OS (including image) we could use:

`Disable-WindowsOptionalFeature –Online -FeatureName MicrosoftWindowsPowerShellV2Root,MicrosoftWindowsPowerShellV2 –Remove`

Or even better Raccine way:
patch `-version, /version` argument

Downgrade attempt example:

`powershell.exe -Version 2.0 -Command {<scriptblock>} -ExecutionPolicy <ExecutionPolicy>`

