### PR TITLE
Update RaccineCfg.cs

### DIFF
--- a/RaccineGUI/RaccineCfg/RaccineElevatedCfg/RaccineCfg.cs
+++ b/RaccineGUI/RaccineCfg/RaccineElevatedCfg/RaccineCfg.cs
@@ -243,7 +243,8 @@ namespace RaccineElevatedCfg
         {
             get
             {
-                string setting = Convert.ToString(Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Raccine", "RulesDir", @"%ProgramFiles%\Raccine\yara"));
+                string dir_name = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Raccine\yara"); 
+                string setting = Convert.ToString(Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Raccine", "RulesDir", dir_name));
                 return setting;
             }
             set


### PR DESCRIPTION
This ensures we always write the expanded path to the registry.  This avoids a crash in raccine.exe where it currently assumes a path in the registry does not contain env vars.
```
:000> k
Child-SP          RetAddr           Call Site
000000f1`96d0d7c0 00007ff6`80ce3ed0 KERNELBASE!RaiseException+0x69
000000f1`96d0d8a0 00007ff6`80c82769 Raccine!_CxxThrowException+0x120
000000f1`96d0d930 00007ff6`80c7d6e3 Raccine!std::filesystem::_Throw_fs_error+0xc9
000000f1`96d0dbc0 00007ff6`80c84261 Raccine!std::filesystem::directory_iterator::directory_iterator+0x83
000000f1`96d0dce0 00007ff6`80c7ccf3 Raccine!YaraRuleRunner::get_yara_rules+0xc1
000000f1`96d0e1c0 00007ff6`80c5fd20 Raccine!YaraRuleRunner::YaraRuleRunner+0x83
000000f1`96d0e300 00007ff6`80c46727 Raccine!EvaluateYaraRules+0x410
000000f1`96d0f230 00007ff6`80cdc9e9 Raccine!wmain+0x357
...
0:000> .f+
02 00000085`12fdd900 00007ff6`80c7d6e3 Raccine!std::filesystem::_Throw_fs_error+0xc9
0:000> dv /V
00000085`12fddb90 @rbp+0x0270                   _Op = 0x00007ff6`80de7b38 "directory_iterator::directory_iterator"
00000085`12fddb98 @rbp+0x0278                _Error = _Path_not_found (0n3)  <<<<<<<<<<<<<<<
00000085`12fddba0 @rbp+0x0280                _Path1 = 0x00000085`12fddfa8
...
0:000> dc 00000187`a5300f20
00000187`a5300f20  00500025 006f0072 00720067 006d0061  %.P.r.o.g.r.a.m.
00000187`a5300f30  00690046 0065006c 00250073 0052005c  F.i.l.e.s.%.\.R.
00000187`a5300f40  00630061 00690063 0065006e 0079005c  a.c.c.i.n.e.\.y.
00000187`a5300f50  00720061 00000061 cdcdcdcd cdcdcdcd  a.r.a...........
00000187`a5300f60  fdfdfdfd abababab abababab abababab  ................
```