### PR TITLE
update to support compiled yara rules

### DIFF
--- a/RaccineGUI/RaccineCfg/RaccineSettings/Program.cs
+++ b/RaccineGUI/RaccineCfg/RaccineSettings/Program.cs
@@ -18,8 +18,8 @@ namespace RaccineSettings
             Application.SetCompatibleTextRenderingDefault(false);
             frmBootstrap f = new frmBootstrap();
             f.Visible = false;
-            Application.Run(f);
-            
+            if (!f.IsDisposed) // our single instance check will exit the constructor early
+                Application.Run(f);
         }
     }
 }

--- a/RaccineGUI/RaccineCfg/RaccineSettings/frmBootstrap.cs
+++ b/RaccineGUI/RaccineCfg/RaccineSettings/frmBootstrap.cs
@@ -42,6 +42,7 @@ namespace RaccineSettings
                 MessageBox.Show(szMessage, "Raccine Startup Error", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 this.singleInstanceMutex.Close();
                 Close();
+                return;
             }
             this.alertEvent = NativeApi.CreateEvent(IntPtr.Zero, false, false, "RaccineAlertEvent");
             if (this.alertEvent == IntPtr.Zero)

--- a/source/RaccineLib/YaraRuleRunner.cpp
+++ b/source/RaccineLib/YaraRuleRunner.cpp
@@ -75,7 +75,7 @@ bool YaraRuleRunner::run_yara_rule_on_process(const std::filesystem::path& yara_
     std::wstring& out_yara_output,
     std::wstring& yara_cmd_optional_defines)
 {
-    std::wstring yara_compiled_rule_option = L"";
+    std::wstring yara_compiled_rule_option = L" ";
 
     if (yara_rule.filename().extension() == compiled_ext)
     {
@@ -118,7 +118,7 @@ bool YaraRuleRunner::run_yara_rule_on_file(const std::filesystem::path& yara_rul
                                            std::wstring& yara_cmd_optional_defines) 
 {
 
-    std::wstring yara_compiled_rule_option = L"";
+    std::wstring yara_compiled_rule_option = L" ";
 
     if (yara_rule.filename().extension() == compiled_ext)
     {

--- a/source/RaccineLib/YaraRuleRunner.cpp
+++ b/source/RaccineLib/YaraRuleRunner.cpp
@@ -8,8 +8,6 @@ YaraRuleRunner::YaraRuleRunner(const std::filesystem::path& yara_rules_dir, cons
     m_raccine_program_directory(raccine_program_directory),
     m_yara_rules(get_yara_rules(yara_rules_dir))
 {
-    m_std_output_read = FileHandleWrapper(INVALID_HANDLE_VALUE);
-    m_std_output_write = FileHandleWrapper(INVALID_HANDLE_VALUE);
 }
 
 bool YaraRuleRunner::run_yara_rules_on_process(const DWORD dwPid,
@@ -77,8 +75,15 @@ bool YaraRuleRunner::run_yara_rule_on_process(const std::filesystem::path& yara_
     std::wstring& out_yara_output,
     std::wstring& yara_cmd_optional_defines)
 {
+    std::wstring yara_compiled_rule_option = L"";
+
+    if (yara_rule.filename().extension() == compiled_ext)
+    {
+        yara_compiled_rule_option = L" -C ";
+    }
+
     std::wstring yara_command_line = L"\"" + m_raccine_program_directory.wstring() + L"\\"
-        + YARA_INSTANCE + L"\" \"" + yara_rule.wstring() + L"\" " + std::to_wstring(dwPid) + L" -d MemoryScan=1 " + yara_cmd_optional_defines;
+        + YARA_INSTANCE + L"\"" + yara_compiled_rule_option + L"\"" + yara_rule.wstring() + L"\" " + std::to_wstring(dwPid) + L" -d MemoryScan=1 " + yara_cmd_optional_defines;
 
 
     HANDLE readpipe = INVALID_HANDLE_VALUE;
@@ -112,8 +117,16 @@ bool YaraRuleRunner::run_yara_rule_on_file(const std::filesystem::path& yara_rul
                                            std::wstring& out_yara_output,
                                            std::wstring& yara_cmd_optional_defines) 
 {
+
+    std::wstring yara_compiled_rule_option = L"";
+
+    if (yara_rule.filename().extension() == compiled_ext)
+    {
+        yara_compiled_rule_option = L" -C ";
+    }
+
     std::wstring yara_command_line = L"\"" + m_raccine_program_directory.wstring() + L"\\"
-        + YARA_INSTANCE + L"\" \"" + yara_rule.wstring() + L"\" " + target_file.wstring() + L" " + yara_cmd_optional_defines;
+        + YARA_INSTANCE + L"\"" + yara_compiled_rule_option + L"\"" + yara_rule.wstring() + L"\" " + target_file.wstring() + L" " + yara_cmd_optional_defines;
 
 
     HANDLE readpipe = INVALID_HANDLE_VALUE;
@@ -210,11 +223,18 @@ std::vector<std::filesystem::path> YaraRuleRunner::get_yara_rules(const std::fil
 {
     std::vector<std::filesystem::path> yara_rules;
     //wprintf(L"Checking Rules Directory: %s\n", yara_rules_dir.c_str());
-    const std::wstring ext(L".yar");
+
     for (const auto& p : std::filesystem::directory_iterator(yara_rules_dir.c_str())) {
-        if (p.path().extension() == ext) {
-            //wprintf(L"Found: %s\n", p.path().c_str());
+        if (p.path().extension() == compiled_ext) {
             yara_rules.push_back(p.path());
+        }
+    }
+    if (yara_rules.size() == 0)
+    {
+        for (const auto& p : std::filesystem::directory_iterator(yara_rules_dir.c_str())) {
+            if (p.path().extension() == ext) {
+                yara_rules.push_back(p.path());
+            }
         }
     }
     return yara_rules;

--- a/source/RaccineLib/YaraRuleRunner.h
+++ b/source/RaccineLib/YaraRuleRunner.h
@@ -5,8 +5,15 @@
 #include "HandleWrapper.h"
 
 #define YARA_RESULTS_SUFFIX L".out"
+#ifdef _WIN64
 #define YARA_INSTANCE  L"yara64.exe"
+#elif defined _WIN32 
+#define YARA_INSTANCE  L"yara86.exe"
+#endif
 constexpr UINT TIMEOUT = 5000;
+
+const std::wstring ext(L".yar");
+const std::wstring compiled_ext(L".yarc");
 
 class YaraRuleRunner final
 {
@@ -59,7 +66,4 @@ private:
     const std::filesystem::path m_raccine_program_directory;
 
     std::vector<std::filesystem::path> m_yara_rules;
-
-    FileHandleWrapper m_std_output_read;
-    FileHandleWrapper m_std_output_write;
 };


### PR DESCRIPTION
This update adds support compiled yara rules--in both raccine and the rules sync-er.
The installer needs to add yarac64.exe or yarac86.exe to %programfile%\raccine.  The installer may want to invoke the rule syncer to download the rules and compile them.